### PR TITLE
Add declarative SDL workflow for MySQL

### DIFF
--- a/.github/workflows/declarative-release-action-mysql.yml
+++ b/.github/workflows/declarative-release-action-mysql.yml
@@ -17,7 +17,7 @@ env:
   BYTEBASE_URL: https://valid-just-tadpole.ngrok-free.app
   BYTEBASE_SERVICE_ACCOUNT: api@service.bytebase.com # set service account via environment variable
   BYTEBASE_SERVICE_ACCOUNT_SECRET: ${{ secrets.BYTEBASE_SERVICE_ACCOUNT_SECRET }} # set service account secret via environment variable
-  BYTEBASE_PROJECT: "projects/mysql-project"
+  BYTEBASE_PROJECT: "projects/mysql-project-gyy6"
 
 jobs:
   build:

--- a/.github/workflows/declarative-release-action-mysql.yml
+++ b/.github/workflows/declarative-release-action-mysql.yml
@@ -1,0 +1,93 @@
+name: Declarative rollout for MySQL using bytebase-action image
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "schema-mysql/*.sql"
+
+# cancel previous workflow run if a new workflow run is triggered
+# to prevent multiple rollout
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
+env:
+  BYTEBASE_URL: https://valid-just-tadpole.ngrok-free.app
+  BYTEBASE_SERVICE_ACCOUNT: api@service.bytebase.com # set service account via environment variable
+  BYTEBASE_SERVICE_ACCOUNT_SECRET: ${{ secrets.BYTEBASE_SERVICE_ACCOUNT_SECRET }} # set service account secret via environment variable
+  BYTEBASE_PROJECT: "projects/mysql-project"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Build app and upload
+        run: |
+          echo "Building..."
+          echo "Build done!"
+          echo "Uploading..."
+          echo "Upload done!"
+  create-rollout:
+    needs: build
+    runs-on: ubuntu-latest # use self-hosted machines if your Bytebase runs in internal networks.
+    container:
+      image: bytebase/bytebase-action:latest
+    outputs:
+      bytebase-plan: ${{ steps.set-output.outputs.plan }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Roll out database change
+        env:
+          BYTEBASE_TARGETS: "instances/mysql-test-instance-05k8/databases/testdb,instances/mysql-test-instance-05k8/databases/proddb"
+          FILE_PATTERN: "schema-mysql/*.sql"
+          BYTEBASE_OUTPUT: ${{ runner.temp }}/bytebase-metadata.json
+        run: |
+          bytebase-action rollout --url=${{ env.BYTEBASE_URL }} --project=${{ env.BYTEBASE_PROJECT }} --file-pattern=${{ env.FILE_PATTERN }} --targets=${{ env.BYTEBASE_TARGETS }} --declarative --output=${{ env.BYTEBASE_OUTPUT }}
+      - name: Set output
+        id: set-output
+        run: |
+          PLAN=$(jq -r .plan ${{ runner.temp }}/bytebase-metadata.json)
+          echo "plan=$PLAN" >> $GITHUB_OUTPUT
+  deploy-to-test:
+    needs: create-rollout
+    runs-on: ubuntu-latest # use self-hosted machines if your Bytebase runs in internal networks.
+    environment: test
+    container:
+      image: bytebase/bytebase-action:latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Roll out database change
+        env:
+          BYTEBASE_TARGET_STAGE: environments/test
+        run: |
+          bytebase-action rollout --url=${{ env.BYTEBASE_URL }} --project=${{ env.BYTEBASE_PROJECT }} --target-stage=${{ env.BYTEBASE_TARGET_STAGE }}  --plan=${{ needs.create-rollout.outputs.bytebase-plan }}
+      - name: Deploy app
+        run: |
+          echo "Deploying app to test environment..."
+          echo "Deploy app to test environment done!"
+  deploy-to-prod:
+    needs:
+      - deploy-to-test
+      - create-rollout
+    runs-on: ubuntu-latest
+    environment: prod
+    container:
+      image: bytebase/bytebase-action:latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: rollout
+        env:
+          BYTEBASE_TARGET_STAGE: environments/prod
+        run: |
+          bytebase-action rollout --url=${{ env.BYTEBASE_URL }} --project=${{ env.BYTEBASE_PROJECT }} --target-stage=${{ env.BYTEBASE_TARGET_STAGE }}  --plan=${{ needs.create-rollout.outputs.bytebase-plan }}
+      - name: Deploy app
+        run: |
+          echo "Deploying app to prod environment..."
+          echo "Deploy app to prod environment done!"

--- a/.github/workflows/declarative-sql-review-action-mysql.yml
+++ b/.github/workflows/declarative-sql-review-action-mysql.yml
@@ -24,7 +24,7 @@ jobs:
             BYTEBASE_URL: https://valid-just-tadpole.ngrok-free.app
             BYTEBASE_SERVICE_ACCOUNT: api@service.bytebase.com # set service account via environment variable
             BYTEBASE_SERVICE_ACCOUNT_SECRET: ${{ secrets.BYTEBASE_SERVICE_ACCOUNT_SECRET }} # set service account secret via environment variable
-            BYTEBASE_PROJECT: "projects/mysql-project"
+            BYTEBASE_PROJECT: "projects/mysql-project-gyy6"
             BYTEBASE_TARGETS: "instances/mysql-test-instance-05k8/databases/proddb"
             FILE_PATTERN: "schema-mysql/*.sql"
         run: |

--- a/.github/workflows/declarative-sql-review-action-mysql.yml
+++ b/.github/workflows/declarative-sql-review-action-mysql.yml
@@ -1,0 +1,31 @@
+name: SQL review on pull request with declarative release for MySQL using bytebase-action image
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "schema-mysql/*.sql"
+      - ".bytebase/sql-review.md"
+
+jobs:
+  check-release-on-prod:
+    permissions:
+        pull-requests: write # write permission required to allow the action writes the check results to the comment.
+    runs-on: ubuntu-latest # use self-hosted machines if your Bytebase runs in internal networks.
+    container:
+      image: bytebase/bytebase-action:latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Check release
+        env:
+            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # set GITHUB_TOKEN because the 'Check release' step needs it to comment the pull request with check results.
+            BYTEBASE_URL: https://valid-just-tadpole.ngrok-free.app
+            BYTEBASE_SERVICE_ACCOUNT: api@service.bytebase.com # set service account via environment variable
+            BYTEBASE_SERVICE_ACCOUNT_SECRET: ${{ secrets.BYTEBASE_SERVICE_ACCOUNT_SECRET }} # set service account secret via environment variable
+            BYTEBASE_PROJECT: "projects/mysql-project"
+            BYTEBASE_TARGETS: "instances/mysql-test-instance-05k8/databases/proddb"
+            FILE_PATTERN: "schema-mysql/*.sql"
+        run: |
+          bytebase-action check --url=${{ env.BYTEBASE_URL }} --project=${{ env.BYTEBASE_PROJECT }} --targets=${{ env.BYTEBASE_TARGETS }} --file-pattern=${{ env.FILE_PATTERN }} --declarative --custom-rules "$(cat .bytebase/sql-review.md)"

--- a/schema-mysql/schema.sql
+++ b/schema-mysql/schema.sql
@@ -1,0 +1,15 @@
+CREATE TABLE `employee` (
+  `id` int NOT NULL AUTO_INCREMENT,
+  `name` varchar(255) NOT NULL,
+  `email` varchar(255) NOT NULL,
+  `created_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `employee_email_key` (`email`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE `department` (
+  `id` int NOT NULL AUTO_INCREMENT,
+  `name` varchar(255) NOT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `department_name_key` (`name`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;


### PR DESCRIPTION
## Summary
- Add `schema-mysql/schema.sql` with a starter MySQL DDL schema (`employee`, `department`)
- Add `declarative-release-action-mysql.yml`: build → create-rollout → test (auto) → prod (manual approval), triggered on push to `main` touching `schema-mysql/*.sql`
- Add `declarative-sql-review-action-mysql.yml`: PR check against `proddb`, reusing `.bytebase/sql-review.md`

Mirrors the existing Postgres declarative pipeline (`declarative-release-action.yml` / `declarative-sql-review-action.yml`), targeting `projects/mysql-project`, instance `mysql-test-instance-05k8`, databases `testdb`/`proddb`.

## Test plan
- [ ] PR check workflow runs and comments on this PR
- [ ] Merge to `main` and confirm the rollout workflow creates a plan and deploys to `testdb`
- [ ] Approve the `prod` environment gate and confirm deploy to `proddb`